### PR TITLE
Adds line numbers to violation list

### DIFF
--- a/web-ui/src/client/app/components/violations.jsx
+++ b/web-ui/src/client/app/components/violations.jsx
@@ -63,6 +63,16 @@ export function Violation(props) {
       >
         <ViolationPaths paths={paths} />
       </If>
+
+      <If
+        test={() => !!violation.start_line || !!violation.end_line}
+        dataTestId="if-violation-lines"
+      >
+        <ViolationLines
+          startLine={violation.start_line}
+          endLine={violation.end_line}
+        />
+      </If>
     </li>
   );
 }
@@ -97,6 +107,14 @@ export function ViolationPaths(props) {
         })}
       </ul>
     </span>
+  );
+}
+
+export function ViolationLines(props) {
+  return (
+    <p>
+      Lines: {props.startLine || '?'}&ndash;{props.endLine || '?'}
+    </p>
   );
 }
 

--- a/web-ui/src/client/app/containers/app.jsx
+++ b/web-ui/src/client/app/containers/app.jsx
@@ -31,10 +31,22 @@ export function App(props) {
             />
             API Linter
           </Link>{' '}
-          - an UI instance of the{' '}
-          <Link to="https://github.com/zalando/zally" target="_blank">
-            'Zally' open source project
-          </Link>
+          - check if your&nbsp;
+          <a
+            href="https://github.com/OAI/OpenAPI-Specification"
+            target="_blank"
+            className="dc-link"
+          >
+            OpenAPI v3 Schema
+          </a>{' '}
+          conforms to&nbsp;
+          <a
+            href="https://internal-docs.nova.infinitec.solutions/api-guidelines/"
+            target="_blank"
+            className="dc-link"
+          >
+            Infinitec's REST API Guidelines
+          </a>
         </h1>
         {OAUTH_ENABLED === true ? (
           <UserInfo

--- a/web-ui/src/client/app/containers/violations-tab.jsx
+++ b/web-ui/src/client/app/containers/violations-tab.jsx
@@ -19,25 +19,6 @@ export function ViolationsTab({
   }
   return (
     <div className="dc-container">
-      <h4 className="dc-h4">
-        Check if your&nbsp;
-        <a
-          href="http://swagger.io/specification/"
-          target="_blank"
-          className="dc-link"
-        >
-          SWAGGER Schema
-        </a>{' '}
-        conforms to&nbsp;
-        <a
-          href="http://zalando.github.io/restful-api-guidelines/"
-          target="_blank"
-          className="dc-link"
-        >
-          Zalando's REST API Guidelines
-        </a>
-      </h4>
-
       <ul className="dc-tab">
         <IndexLinkContainer
           to="/"

--- a/web-ui/src/client/app/index.scss
+++ b/web-ui/src/client/app/index.scss
@@ -91,7 +91,7 @@ footer {
  * page container
  */
 .page-container {
-  padding: 10rem 2.4rem 1.2rem;
+  padding: 7rem 2.4rem 1.2rem;
   height: calc(100% - 5rem);
   position: relative;
 }


### PR DESCRIPTION
This is my stab at making the linter UI a bit more usable after working with it for ~20 minutes.

It adds line numbers to details of each violation, which (to me) was very helpful while working with larger OpenAPI files.

It also collapses two headers at the top into just one to make more room for the editor and violations pane and updates the description and links in the headers.

How to verify:
1. checkout this branch
2. `./build-and-run.sh`
3. open `http://localhost:8080/editor`
4. see that there's just one header "API Linter - check if your OpenAPI v3 Schema conforms to Infinitec's REST API Guidelines" instead of two: "API Linter - an UI instance of the 'Zally' open source project" + "Check if your SWAGGER Schema conforms to Zalando's REST API Guidelines"
5. paste this into editor:
```
openapi: 3.0.2
info:
  title: Some API
  version: a.b.c
paths:
  /things:
    get:
      summary: Get things
```
and hit "Validate"
6. see that line numbers are visible in the violations pane, e.g.
> MUST – Use Semantic Versioning
> ...
> Lines: 4–4